### PR TITLE
URL Casing Fix

### DIFF
--- a/SucculentForum/SucculentApp/views.py
+++ b/SucculentForum/SucculentApp/views.py
@@ -15,4 +15,4 @@ def register(request):
 
     else:
         form = UserCreationForm()
-        return render(request, 'accounts/register.html', {'form':form})
+        return render(request, 'accounts/Register.html', {'form':form})


### PR DESCRIPTION
When I ran this on my linux machine it couldn't find the template.
Line 18 in SucculentApp/views.py called the Template as "accounts/register.html"
The Template is Register.html.
The casing seems to matter on Linux machines but not Windows.  Not sure why this is, but it will get deployed on Linux, so we need to be conscious of this.